### PR TITLE
Bundle OpenJDK 21 to support 24w12a and later versions.

### DIFF
--- a/org.polymc.PolyMC.yml
+++ b/org.polymc.PolyMC.yml
@@ -42,7 +42,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/PolyMC/PolyMC.git
-        tag: 6.1
+        tag: 6.1-flatpakfix
   - name: openjdk
     buildsystem: simple
     build-commands:

--- a/org.polymc.PolyMC.yml
+++ b/org.polymc.PolyMC.yml
@@ -3,6 +3,7 @@ runtime: org.kde.Platform
 runtime-version: "5.15-22.08"
 sdk: org.kde.Sdk
 sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk21
   - org.freedesktop.Sdk.Extension.openjdk17
   - org.freedesktop.Sdk.Extension.openjdk8
 add-extensions:
@@ -46,6 +47,8 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/jdk/
+      - /usr/lib/sdk/openjdk21/install.sh
+      - mv /app/jre /app/jdk/21
       - /usr/lib/sdk/openjdk17/install.sh
       - mv /app/jre /app/jdk/17
       - /usr/lib/sdk/openjdk8/install.sh


### PR DESCRIPTION
The title and the changes say it all.

Fun fact: without this, 24w14potato is the most recent playable version in the Flatpak release.